### PR TITLE
Added support to choose hypervizor type

### DIFF
--- a/providers/domain_kvm.rb
+++ b/providers/domain_kvm.rb
@@ -22,6 +22,8 @@ action :define do
         :vcpu   => new_resource.vcpu,
         :arch   => libvirt_arch,
         :boot   => new_resource.boot,
+        :type   => new_resource.type,
+        :emulator   => new_resource.emulator,
         :uuid   => ::UUIDTools::UUID.random_create
       )
       action :nothing

--- a/resources/domain.rb
+++ b/resources/domain.rb
@@ -10,3 +10,5 @@ attribute :memory, :kind_of => [Integer, String], :required => true
 attribute :arch, :kind_of => String, :required => true
 attribute :boot, :kind_of => String, :default => 'hd'
 attribute :uri, :kind_of => String, :default => 'qemu:///system'
+attribute :type, :kind_of => String, :default => 'kvm'
+attribute :emulator, :kind_of => String, :default => '/usr/bin/kvm'

--- a/templates/default/kvm_domain.xml
+++ b/templates/default/kvm_domain.xml
@@ -1,4 +1,4 @@
-<domain type='kvm'>
+<domain type='<%= @type %>' >
   <name><%= @name %></name>
   <currentMemory><%= @memory %></currentMemory>
   <memory><%= @memory %></memory>
@@ -16,7 +16,7 @@
   <on_reboot>restart</on_reboot>
   <on_crash>restart</on_crash>
   <devices>
-    <emulator>/usr/bin/kvm</emulator>
+    <emulator><%= @emulator %></emulator>
     <input type='mouse' bus='ps2'/>
     <graphics type='vnc' port='-1' autoport='yes'/>
     <serial type='pty'>


### PR DESCRIPTION
(for example you must use "qemu" not "kvm" in ubuntu16 on hosts withous hardware virtualization feauture)